### PR TITLE
feat(clay-link): Trigger an "itemClicked" event and improve a11y

### DIFF
--- a/packages/clay-link/demos/index.html
+++ b/packages/clay-link/demos/index.html
@@ -108,10 +108,24 @@
 		new metal.ClayLink(
 			{
 				ariaLabel: 'My Link',
-				href: '#link-icons',
-				icon: 'add-cell',
+				defaultEventHandler: {
+					handleItemClicked(event) {
+						event.preventDefault();
+
+						var linkElement = event.currentTarget;
+						var href = linkElement.getAttribute('href');
+
+						if (confirm('Are you sure you want to leave this site?')) {
+							location.href = href;
+						}
+					}
+				},
+				href: 'https://liferay.com',
+				icon: 'link',
 				iconAlignment: 'right',
+				label: 'Visit Liferay',
 				spritemap: spritemap,
+				title: 'Visit Liferay\'s website',
 			},
 			'#link-icons'
 		);

--- a/packages/clay-link/src/ClayLink.js
+++ b/packages/clay-link/src/ClayLink.js
@@ -10,7 +10,30 @@ import templates from './ClayLink.soy.js';
  * Implementation of the Metal Clay Link.
  * @extends ClayComponent
  */
-class ClayLink extends ClayComponent {}
+class ClayLink extends ClayComponent {
+	/**
+	 * @inheritDoc
+	 */
+	attached() {
+		this.addListener('click', this._handleClick, true);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	disposed() {
+		this.removeListener('click', this._handleClick);
+	}
+
+	/**
+	 * Handles click.
+	 * @param {!Event} event
+	 * @protected
+	 */
+	_handleClick(event) {
+		this.emit('itemClicked', event);
+	}
+}
 
 /**
  * State definition.

--- a/packages/clay-link/src/ClayLink.soy
+++ b/packages/clay-link/src/ClayLink.soy
@@ -77,6 +77,7 @@
 			{param imageSrc: $imageSrc /}
 			{param label: $label /}
 			{param spritemap: $spritemap /}
+			{param title: $title /}
 		{/call}
 	</a>
 {/template}
@@ -91,6 +92,7 @@
 	{@param? imageSrc: string}
 	{@param? label: html|string}
 	{@param? spritemap: string}
+	{@param? title: string}
 
 	{if $imageSrc}
 		<img alt="{$imageAlt}" class="img-fluid" src="{$imageSrc}" />
@@ -112,6 +114,10 @@
 				{param spritemap: $spritemap /}
 			{/call}
 		{/if}
+	{/if}
+
+	{if $title}
+		<span class="sr-only">{$title}</span>
 	{/if}
 {/template}
 


### PR DESCRIPTION
This allows the "defaultEventHandler" to have an
"handleItemClicked" method (similar to clay-dropdown), which
can be used to prevent navigation or do anything else required
when a link is clicked.

The (ClayLink) template has also been updated to include
the title for screen readers.